### PR TITLE
Update blacklist function to handle missing/invalid hotkeys

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -112,16 +112,6 @@ class Miner(BaseMinerNeuron):
             return True, f"Unrecognized hotkey {synapse.dendrite.hotkey}"
 
         uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
-        if (
-            not self.config.blacklist.allow_non_registered
-            and synapse.dendrite.hotkey not in self.metagraph.hotkeys
-        ):
-            # Ignore requests from un-registered entities.
-            bt.logging.trace(
-                f"Blacklisting un-registered hotkey {synapse.dendrite.hotkey}"
-            )
-            return True, "Unrecognized hotkey"
-
         if self.config.blacklist.force_validator_permit:
             # If the config is set to force validator permit, then we should only allow requests from validators.
             if not self.metagraph.validator_permit[uid]:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -100,6 +100,17 @@ class Miner(BaseMinerNeuron):
 
         Otherwise, allow the request to be processed further.
         """
+        if not synapse.dendrite.hotkey:
+            return True, "Hotkey not provided"
+        registered = synapse.dendrite.hotkey in self.metagraph.hotkeys
+        if self.config.blacklist.allow_non_registered and not registered:
+            return False, "Allowing un-registered hotkey"
+        elif not registered:
+            bt.logging.trace(
+                f"Blacklisting un-registered hotkey {synapse.dendrite.hotkey}"
+            )
+            return True, f"Unrecognized hotkey {synapse.dendrite.hotkey}"
+
         uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
         if (
             not self.config.blacklist.allow_non_registered


### PR DESCRIPTION
Currently you can set hotkey to null or a random string and bypass the blacklist function.