### PR TITLE
feat: support reviewing marketplace tasks

### DIFF
--- a/validator-api/app.py
+++ b/validator-api/app.py
@@ -46,6 +46,7 @@ from validator_api.database.crud.focusvideo import (
     already_purchased_max_focus_tao, check_availability,
     get_all_available_focus, get_miner_purchase_stats, get_video_owner_coldkey,
     mark_video_rejected, mark_video_submitted, set_focus_video_score)
+from validator_api.database.models.focus_video_record import FocusVideoRecord, FocusVideoStateExternal
 from validator_api.dataset_upload import (audio_dataset_uploader,
                                           video_dataset_uploader)
 from validator_api.limiter import limiter
@@ -260,6 +261,18 @@ async def run_focus_scoring(
     score_details = None
     embeddings = None
     try:
+        with get_db_context() as db:
+            video_record = db.query(FocusVideoRecord).filter(
+                FocusVideoRecord.video_id == video_id,
+                FocusVideoRecord.deleted_at.is_(None)
+            ).first()
+            if video_record is None:
+                raise HTTPException(404, detail="Focus video not found")
+            if video_record.task_type.value == TaskType.MARKETPLACE.value:
+                db.query(FocusVideoRecord).filter(FocusVideoRecord.video_id == video_id).update({"processing_state": FocusVideoStateExternal.PENDING_HUMAN_REVIEW.value})
+                db.commit()
+                return {"success": True}
+
         score_details, embeddings = await focus_scoring_service.score_video(video_id, focusing_task, focusing_description)
         print(
             f"Score for focus video <{video_id}>: {score_details.final_score}")

--- a/validator-api/validator_api/database/models/focus_video_record.py
+++ b/validator-api/validator_api/database/models/focus_video_record.py
@@ -14,9 +14,11 @@ import enum
 class TaskType(enum.Enum):
     USER = "USER"
     BOOSTED = "BOOSTED"
+    MARKETPLACE = "MARKETPLACE"
 
 class FocusVideoStateExternal(enum.Enum):
     PROCESSING = "PROCESSING"
+    PENDING_HUMAN_REVIEW = "PENDING_HUMAN_REVIEW"
     READY = "READY"
     REJECTED = "REJECTED"
     SUBMITTED = "SUBMITTED"
@@ -26,6 +28,7 @@ class FocusVideoStateInternal(enum.Enum):
     # OMEGA Focus user facing states
     IN_PROGRESS = "IN_PROGRESS"
     PROCESSING = "PROCESSING"  # User has completed task, we are currently calculating their score and checking if the video is legit
+    PENDING_HUMAN_REVIEW = "PENDING_HUMAN_REVIEW"  # Video belongs to a marketplace task and needs human review
     READY = "READY"  # Score has been calculated and task is eligible for submission
     REJECTED = "REJECTED"  # Turns out that the task was NOT eligible for submission, lifecycle ended here
     SUBMITTED = "SUBMITTED"  # User has pressed "Submit" and the task is now listed on the marketplace, for SN24 miners to buy


### PR DESCRIPTION
Adds support for "validating" marketplace tasks. Validation for such tasks is done manually (at least for now), so all we do in this case is flag it for human review and return early.

End to end testing/demo is [here](https://erichasegawa.neetorecord.com/watch/77593897b4a5b570fd0a)